### PR TITLE
Fix wrong elements in pdb2pqr

### DIFF
--- a/pdb2pqr/src/aa.py
+++ b/pdb2pqr/src/aa.py
@@ -100,7 +100,7 @@ class Amino(Residue):
                 atom = Atom(a, "ATOM", self)
                 self.addAtom(atom)
 
-    def createAtom(self, atomname, newcoords):
+    def createAtom(self, atomname, newcoords, templateatom=None, overwriteelement=None):
         """
             Create an atom.  Override the generic residue's version of
             createAtom().
@@ -109,7 +109,10 @@ class Amino(Residue):
                 atomname:  The name of the atom (string)
                 newcoords: The coordinates of the atom (list).
         """
-        oldatom = self.atoms[0]
+        if templateatom is not None:
+            oldatom = templateatom
+        else:
+            oldatom = self.atoms[0]
         newatom = Atom(oldatom, "ATOM", self)
         newatom.set("x",newcoords[0])
         newatom.set("y",newcoords[1])
@@ -117,6 +120,8 @@ class Amino(Residue):
         newatom.set("name", atomname)
         newatom.set("occupancy",1.00)
         newatom.set("tempFactor",0.00)
+        if overwriteelement is not None:
+            newatom.set("element", overwriteelement)
         newatom.added = 1
         self.addAtom(newatom)
 
@@ -755,7 +760,7 @@ class WAT(Residue):
                 oldatom = self.getAtom(atomname)
                 oldatom.set("altLoc","")
 
-    def createAtom(self, atomname, newcoords):
+    def createAtom(self, atomname, newcoords, overwriteelement=None):
         """
             Create a water atom.  Note the HETATM field.
 
@@ -771,6 +776,8 @@ class WAT(Residue):
         newatom.set("name", atomname)
         newatom.set("occupancy",1.00)
         newatom.set("tempFactor",0.00)
+        if overwriteelement is not None:
+            newatom.set("element", overwriteelement)
         newatom.added = 1
         self.addAtom(newatom)
 
@@ -839,7 +846,7 @@ class LIG(Residue):
                 oldatom = self.getAtom(atomname)
                 oldatom.set("altLoc","")
 
-    def createAtom(self, atomname, newcoords):
+    def createAtom(self, atomname, newcoords, overwriteelement=None):
         """
             Create a water atom.  Note the HETATM field.
 
@@ -855,6 +862,8 @@ class LIG(Residue):
         newatom.set("name", atomname)
         newatom.set("occupancy",1.00)
         newatom.set("tempFactor",0.00)
+        if overwriteelement is not None:
+            newatom.set("element", overwriteelement)
         newatom.added = 1
         self.addAtom(newatom)
 

--- a/pdb2pqr/src/hydrogens.py
+++ b/pdb2pqr/src/hydrogens.py
@@ -393,7 +393,7 @@ class Optimize:
         for i in range(3):
             newcoords.append(vec[i]/dist + atom.getCoords()[i])
             
-        residue.createAtom(addname, newcoords)
+        residue.createAtom(addname, newcoords, overwriteelement='H')
         newatom = residue.getAtom(addname)
         self.routines.cells.addCell(newatom)
 
@@ -418,7 +418,7 @@ class Optimize:
         # Make the atom
 
         newcoords = findCoordinates(2, coords, refcoords, refatomcoords)
-        residue.createAtom(addname, newcoords)
+        residue.createAtom(addname, newcoords, overwriteelement='H')
 
         # Set the bonds (since not in reference structure)
 
@@ -443,7 +443,7 @@ class Optimize:
         # Make the atom
 
         newcoords = findCoordinates(2, coords, refcoords, refatomcoords)
-        residue.createAtom(addname, newcoords)
+        residue.createAtom(addname, newcoords, overwriteelement='H')
 
     def makeAtomWithOneBondLP(self, atom, addname):
         """
@@ -457,6 +457,8 @@ class Optimize:
         for refname in atom.reference.bonds:
             if refname.startswith("H"): break
 
+        assert refname.startswith("H"), "No hydrogen atom found in reference residue"
+
         nextatom = atom.bonds[0]
         coords = [atom.getCoords(), nextatom.getCoords()]
         refcoords = [residue.reference.map[atom.name].getCoords(), \
@@ -466,7 +468,7 @@ class Optimize:
         # Make the atom
 
         newcoords = findCoordinates(2, coords, refcoords, refatomcoords)
-        residue.createAtom(addname, newcoords)     
+        residue.createAtom(addname, newcoords, overwriteelement='H')     
 
         # Set the bonds (since not in reference structure)
 
@@ -606,7 +608,7 @@ class Optimize:
         
         # Try the first position
         
-        residue.createAtom(newname, loc1)
+        residue.createAtom(newname, loc1, overwriteelement='H')
         if self.isHbond(donor, acc):
             besten = self.getPairEnergy(donor, acc)
             bestcoords = loc1
@@ -660,7 +662,7 @@ class Optimize:
 
         # Try the first position
         
-        residue.createAtom(newname, loc1)
+        residue.createAtom(newname, loc1, overwriteelement='X')
         newatom = residue.getAtom(newname)
         angle = abs(self.getHbondangle(donorhatom, acc, newatom))
         if angle < bestangle:
@@ -729,7 +731,7 @@ class Optimize:
             position.
         """
         residue = donor.residue
-        residue.createAtom(newname, loc)
+        residue.createAtom(newname, loc, overwriteelement='H')
         if self.isHbond(donor, acc):
             newatom = residue.getAtom(newname)
             self.routines.cells.addCell(newatom)
@@ -753,7 +755,7 @@ class Optimize:
             if donorhatom.isHydrogen() and \
                self.getHbondangle(acc, donor, donorhatom) < ANGLE_CUTOFF: break
 
-        residue.createAtom(newname, loc)
+        residue.createAtom(newname, loc, overwriteelement='X')
         newatom = residue.getAtom(newname)
 
         # Remove if geometry does not work
@@ -835,7 +837,7 @@ class Flip(Optimize):
 
         for name in map:
             newname = "%sFLIP" % name
-            residue.createAtom(newname, map[name])
+            residue.createAtom(newname, map[name], templateatom=residue.getAtom(name))
             newatom = residue.getAtom(newname)
             self.routines.cells.addCell(newatom)
 
@@ -1213,7 +1215,7 @@ class Alcoholic(Optimize):
            
         elif len(atom.bonds) == 2:    
             loc1, loc2 = self.getPositionsWithTwoBonds(atom)
-            residue.createAtom(addname, loc1)
+            residue.createAtom(addname, loc1, overwriteelement='H')
             newatom = residue.getAtom(addname)
             self.routines.cells.addCell(newatom)
             
@@ -1255,7 +1257,7 @@ class Alcoholic(Optimize):
         elif len(atom.bonds) == 3:
           
             loc = self.getPositionWithThreeBonds(atom)
-            residue.createAtom(addname, loc)
+            residue.createAtom(addname, loc, overwriteelement='H')
             self.routines.cells.addCell(residue.getAtom(addname))
 
     def complete(self):
@@ -1469,7 +1471,7 @@ class Water(Optimize):
             else:
                 newcoords = add(atom.getCoords(), [1.0, 0.0, 0.0])      
 
-            residue.createAtom(addname, newcoords)
+            residue.createAtom(addname, newcoords, overwriteelement='H')
             self.routines.cells.addCell(residue.getAtom(addname))
 
             self.finalize()
@@ -1515,7 +1517,7 @@ class Water(Optimize):
         elif len(atom.bonds) == 2:
 
             loc1, loc2 = self.getPositionsWithTwoBonds(atom)
-            residue.createAtom(addname, loc1)
+            residue.createAtom(addname, loc1, overwriteelement='H')
             newatom = residue.getAtom(addname)
             self.routines.cells.addCell(newatom)
             
@@ -1551,7 +1553,7 @@ class Water(Optimize):
         elif len(atom.bonds) == 3:
 
             loc = self.getPositionWithThreeBonds(atom)
-            residue.createAtom(addname, loc)
+            residue.createAtom(addname, loc, overwriteelement='H')
             self.routines.cells.addCell(residue.getAtom(addname))            
 
           
@@ -1665,7 +1667,7 @@ class Carboxylic(Optimize):
 
             residue.renameAtom(hname, "%s1" % hname)
             newname = "%s2" % hname
-            residue.createAtom(newname, newcoords)
+            residue.createAtom(newname, newcoords, overwriteelement='H')
             newatom = residue.getAtom(newname)
             self.routines.cells.addCell(newatom)
             newatom.refdistance = hatom.refdistance
@@ -2215,7 +2217,7 @@ class hydrogenRoutines:
                         raise PDBInternalError("Could not find necessary atom!")
     
                 newcoords = findCoordinates(3, refcoords, defcoords, defatomcoords)
-                residue.createAtom(hname, newcoords)
+                residue.createAtom(hname, newcoords, overwriteelement='H')
 
             boundname = conf.boundatom
             residue.getAtom(boundname).hacceptor = 0
@@ -2580,7 +2582,6 @@ class hydrogenRoutines:
                 if atom.hacceptor and atom2.hdonor and res == 0:
                     obj2.tryBoth(atom2, atom, obj1)
          
-                   
             ### FOURTH: Complete all residues
     
             for obj in network:  obj.complete()

--- a/pdb2pqr/src/routines.py
+++ b/pdb2pqr/src/routines.py
@@ -708,7 +708,7 @@ class Routines:
                          residue.reference.map[nextatomname].getCoords()]
             refatomcoords = atomref.getCoords()
             newcoords = findCoordinates(2, coords, refcoords, refatomcoords)
-            residue.createAtom(atomname, newcoords)
+            residue.createAtom(atomname, newcoords, overwriteelement='H')
 
             # For LEU and ILE residues only: make sure the Hydrogens are in staggered conformation instead of eclipsed.
 
@@ -750,7 +750,7 @@ class Routines:
             residue.rotateTetrahedral(nextatom, bondatom, 120)
             newcoords = hatom.getCoords()
             residue.rotateTetrahedral(nextatom, bondatom, -120)
-            residue.createAtom(atomname, newcoords)
+            residue.createAtom(atomname, newcoords, overwriteelement='H')
 
             return 1
 
@@ -778,9 +778,9 @@ class Routines:
             # Determine which one hatoms[1] is not in
 
             if distance(hatoms[1].getCoords(), newcoords1) > 0.1:
-                residue.createAtom(atomname, newcoords1)
+                residue.createAtom(atomname, newcoords1, overwriteelement='H')
             else:
-                residue.createAtom(atomname, newcoords2)
+                residue.createAtom(atomname, newcoords2, overwriteelement='H')
 
             return 1
 
@@ -844,7 +844,7 @@ class Routines:
 
                 if len(coords) == 3:
                     newcoords = findCoordinates(3, coords, refcoords, refatomcoords)
-                    residue.createAtom(atomname, newcoords)
+                    residue.createAtom(atomname, newcoords, overwriteelement='H')
                     count += 1
                 else:
                     self.write("Couldn't rebuild %s in %s!\n" % (atomname, residue), 1)
@@ -935,7 +935,7 @@ class Routines:
 
                 else: # Rebuild the atom
                     newcoords = findCoordinates(3, coords, refcoords, refatomcoords)
-                    residue.createAtom(atomname, newcoords)
+                    residue.createAtom(atomname, newcoords, overwriteelement="")
                     self.write("Added %s to %s at coordinates" % (atomname, residue), 1)
                     self.write(" %.3f %.3f %.3f\n" % \
                            (newcoords[0], newcoords[1], newcoords[2]))


### PR DESCRIPTION
workaround for issue of pdb2pqr creating atoms using the first atom of the residue as template. In this case I'm simply fixing the elements in the case of hydrogens and zeroing them in the case of heavy atoms to at least not be wrong